### PR TITLE
Overhaul frame generation, sync and anti-aliasing; fix double cursor

### DIFF
--- a/MetalGoose/CaptureSettings.swift
+++ b/MetalGoose/CaptureSettings.swift
@@ -209,22 +209,14 @@ final class CaptureSettings: ObservableObject {
         case off = "Off"
         case fxaa = "FXAA"
         case smaa = "SMAA"
-        case msaa = "MSAA"
-        case taa = "TAA"
-        
+
         var id: String { rawValue }
-        
-        var isTemporal: Bool {
-            return self == .taa
-        }
-        
+
         var description: String {
             switch self {
             case .off: return "No anti-aliasing - sharpest but aliased"
-            case .fxaa: return "Fast Approximate AA - quick, slight blur"
-            case .smaa: return "Subpixel Morphological AA - high quality edges"
-            case .msaa: return "Multisample AA - hardware-like, clean edges"
-            case .taa: return "Temporal AA - motion-compensated, best quality"
+            case .fxaa: return "Fast Approximate AA - quick, smooths edges on the final image"
+            case .smaa: return "Subpixel Morphological AA - higher quality edge detection"
             }
         }
     }
@@ -242,13 +234,10 @@ final class CaptureSettings: ObservableObject {
     @Published var aaMode: AAMode = .off
     
     @Published var captureCursor: Bool = true
-    @Published var adaptiveSync: Bool = true
     @Published var showMGHUD: Bool = true
     @Published var vsync: Bool = true
-    
+
     @Published var sharpening: Float = 0.5
-    @Published var temporalBlend: Float = 0.1
-    @Published var motionScale: Float = 1.0
     
     var effectiveUpscaleFactor: Float {
         guard scalingType != .off else { return 1.0 }
@@ -262,21 +251,7 @@ final class CaptureSettings: ObservableObject {
     var isFrameGenEnabled: Bool {
         return frameGenMode != .off
     }
-    
-    var isTemporalAAEnabled: Bool {
-        return aaMode == .taa
-    }
-    
-    var outputMultiplier: Float {
-        guard isUpscalingEnabled else { return 1.0 }
-        return scaleFactor.floatValue
-    }
-    
-    var interpolatedFrameCount: Int {
-        guard isFrameGenEnabled else { return 1 }
-        return frameGenMultiplier.intValue
-    }
-    
+
     var effectiveTargetFPS: Int {
         guard isFrameGenEnabled else { return targetFPS.intValue }
         switch frameGenType {
@@ -309,13 +284,10 @@ final class CaptureSettings: ObservableObject {
         defaults.set(frameGenMultiplier.rawValue, forKey: prefix + "frameGenMultiplier")
         defaults.set(aaMode.rawValue, forKey: prefix + "aaMode")
         defaults.set(captureCursor, forKey: prefix + "captureCursor")
-        defaults.set(adaptiveSync, forKey: prefix + "adaptiveSync")
         defaults.set(showMGHUD, forKey: prefix + "showMGHUD")
         defaults.set(vsync, forKey: prefix + "vsync")
         defaults.set(sharpening, forKey: prefix + "sharpening")
-        defaults.set(temporalBlend, forKey: prefix + "temporalBlend")
-        defaults.set(motionScale, forKey: prefix + "motionScale")
-        
+
         if !profiles.contains(name) {
             profiles.append(name)
             defaults.set(profiles, forKey: "MetalGoose.Profiles")
@@ -355,13 +327,10 @@ final class CaptureSettings: ObservableObject {
            
         
         if defaults.object(forKey: prefix + "captureCursor") != nil { captureCursor = defaults.bool(forKey: prefix + "captureCursor") }
-        if defaults.object(forKey: prefix + "adaptiveSync") != nil { adaptiveSync = defaults.bool(forKey: prefix + "adaptiveSync") }
         if defaults.object(forKey: prefix + "showMGHUD") != nil { showMGHUD = defaults.bool(forKey: prefix + "showMGHUD") }
         if defaults.object(forKey: prefix + "vsync") != nil { vsync = defaults.bool(forKey: prefix + "vsync") }
         if defaults.object(forKey: prefix + "sharpening") != nil { sharpening = defaults.float(forKey: prefix + "sharpening") }
-        if defaults.object(forKey: prefix + "temporalBlend") != nil { temporalBlend = defaults.float(forKey: prefix + "temporalBlend") }
-        if defaults.object(forKey: prefix + "motionScale") != nil { motionScale = defaults.float(forKey: prefix + "motionScale") }
-        
+
         selectedProfile = name
     }
     
@@ -375,8 +344,7 @@ final class CaptureSettings: ObservableObject {
         let prefix = "MetalGoose.Profile.\(name)."
         let keys = ["renderScale", "scalingType", "qualityMode", "scaleFactor",
                     "frameGenMode", "frameGenType", "targetFPS", "frameGenMultiplier", "aaMode",
-                    "captureCursor", "adaptiveSync",
-                    "showMGHUD", "vsync", "sharpening", "temporalBlend", "motionScale"]
+                    "captureCursor", "showMGHUD", "vsync", "sharpening"]
         for key in keys {
             defaults.removeObject(forKey: prefix + key)
         }
@@ -392,7 +360,6 @@ final class CaptureSettings: ObservableObject {
 
 struct QualityProfile {
     let sharpnessScale: Float
-    let temporalBlendScale: Float
     let aaThreshold: Float
     let smaaSearchSteps: Int
     let frameGenGradientThreshold: Float
@@ -405,7 +372,6 @@ extension CaptureSettings.QualityMode {
         case .performance:
             return QualityProfile(
                 sharpnessScale: 0.8,
-                temporalBlendScale: 1.2,
                 aaThreshold: 0.18,
                 smaaSearchSteps: 8,
                 frameGenGradientThreshold: 0.08
@@ -413,7 +379,6 @@ extension CaptureSettings.QualityMode {
         case .balanced:
             return QualityProfile(
                 sharpnessScale: 1.0,
-                temporalBlendScale: 1.0,
                 aaThreshold: 0.12,
                 smaaSearchSteps: 12,
                 frameGenGradientThreshold: 0.06
@@ -421,7 +386,6 @@ extension CaptureSettings.QualityMode {
         case .ultra:
             return QualityProfile(
                 sharpnessScale: 1.2,
-                temporalBlendScale: 0.85,
                 aaThreshold: 0.08,
                 smaaSearchSteps: 16,
                 frameGenGradientThreshold: 0.045

--- a/MetalGoose/ContentView.swift
+++ b/MetalGoose/ContentView.swift
@@ -379,10 +379,7 @@ struct ContentView: View {
                               helpText: String(localized: "Include cursor", comment: "Toggle help text"))
 
                     ToggleRow(label: String(localized: "VSync", comment: "Toggle label"), isOn: $settings.vsync,
-                              helpText: String(localized: "Sync to display", comment: "Toggle help text"))
-
-                    ToggleRow(label: String(localized: "Adaptive Sync", comment: "Toggle label"), isOn: $settings.adaptiveSync,
-                              helpText: String(localized: "Auto pacing", comment: "Toggle help text"))
+                              helpText: String(localized: "Sync presentation to the display refresh to avoid tearing", comment: "Toggle help text"))
 
                     SliderRow(label: String(localized: "Sharpness", comment: "Slider label"), value: $settings.sharpening, range: 0...1,
                               helpText: String(localized: "CAS intensity", comment: "Slider help text"))
@@ -474,20 +471,22 @@ struct ContentView: View {
             showAlert = true
             return
         }
-        let targetRefreshRate = Double(settings.targetFPS.intValue)
-        let captureRefreshRate = Int(round(targetRefreshRate))
-        
+        // The panel's refresh rate is the physical ceiling for both capture and
+        // output. Capturing at this rate lets duplicate-frame detection recover
+        // the real source rate so frame generation has headroom.
+        let displayMaxFPS = outputScreen.maximumFramesPerSecond > 0 ? outputScreen.maximumFramesPerSecond : 60
+
         guard let captureManager = windowCaptureManager else { return }
-        
+
         let sourceRes = cgFrame.size
         let scaledOutputSize = outputScreen.frame.size
-        
+
         engine.configure(sourceResolution: sourceRes, outputSize: scaledOutputSize)
-        
-        let success = await captureManager.startCapture(windowID: wid, refreshRate: captureRefreshRate, showsCursor: settings.captureCursor)
+
+        let success = await captureManager.startCapture(windowID: wid, maxFPS: displayMaxFPS)
         if success {
-            await engine.startCaptureFromWindow(captureManager, refreshRate: captureRefreshRate)
-            
+            await engine.startCaptureFromWindow(captureManager, refreshRate: displayMaxFPS)
+
             if let name = app.localizedName {
                 connectedProcessName = name
             } else {
@@ -499,23 +498,22 @@ struct ContentView: View {
             targetDisplayID = displayID
             activeOutputScreen = outputScreen
             isScalingActive = true
-            
+
             let config = OverlayWindowConfig(
                 targetScreen: outputScreen,
                 windowFrame: cgFrame,
                 size: scaledOutputSize,
-                refreshRate: targetRefreshRate,
+                refreshRate: Double(displayMaxFPS),
                 vsyncEnabled: settings.vsync,
-                adaptiveSyncEnabled: settings.adaptiveSync,
                 passThrough: true,
                 scaleFactor: 1.0,
                 captureCursor: settings.captureCursor
             )
-            
+
             if overlay.createOverlay(config: config) {
                 let mtkView = MTKView(frame: CGRect(origin: .zero, size: scaledOutputSize))
                 overlay.setMTKView(mtkView)
-                engine.attachToView(mtkView, refreshRate: captureRefreshRate)
+                engine.attachToView(mtkView, displayRefreshRate: displayMaxFPS)
                 gooseMtkView = mtkView
                 
                 overlay.setTargetWindow(wid, pid: app.processIdentifier)

--- a/MetalGoose/GooseEngine.swift
+++ b/MetalGoose/GooseEngine.swift
@@ -73,8 +73,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
     private var smaaEdgePipeline: MTLComputePipelineState?
     private var smaaWeightPipeline: MTLComputePipelineState?
     private var smaaBlendPipeline: MTLComputePipelineState?
-    private var msaaPipeline: MTLComputePipelineState?
-    private var taaAccumulatePipeline: MTLComputePipelineState?
     private var copyPipeline: MTLComputePipelineState?
 
     // Optical flow / frame generation pipelines
@@ -92,10 +90,7 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
     private var smaaEdgeTexture: MTLTexture?
     private var smaaWeightTexture: MTLTexture?
     private var smaaOutputTexture: MTLTexture?
-    private var msaaTexture: MTLTexture?
-    private var taaHistoryTexture: MTLTexture?
-    private var taaOutputTexture: MTLTexture?
-    
+
     // Vision framework optical flow (ANE/GPU-powered)
     // Managed by VisionFlowProvider class — no instance variables needed here
     
@@ -174,7 +169,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
     private var historyTextureIndex: Int = 0
 
     private var blendTexture: MTLTexture?
-    private var hasTAAHistory: Bool = false
     private var lastProcessedSize: CGSize = .zero
 
     private var scalingType: CaptureSettings.ScalingType = .off
@@ -183,14 +177,11 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
     private var renderScaleFactor: Float = 1.0
     private var scaleFactor: Float = 1.0
     private var sharpness: Float = 0.5
-    private var temporalBlend: Float = 0.1
-    private var captureCursor: Bool = true
     private var frameGenEnabled: Bool = false
     private var frameGenMode: CaptureSettings.FrameGenMode = .off
     private var frameGenType: CaptureSettings.FrameGenType = .adaptive
     private var targetFPS: Int = 120
     private var frameGenMultiplier: Int = 2
-    private var adaptiveSync: Bool = true
     private var vsyncEnabled: Bool = true
     private var qualityProfile: QualityProfile = CaptureSettings.QualityMode.balanced.profile
     
@@ -239,13 +230,12 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         casPipeline = makeCompute("contrastAdaptiveSharpening")
         copyPipeline = makeCompute("copyTexture")
         
-        // Anti-aliasing pipelines
+        // Anti-aliasing pipelines (post-process only: FXAA + SMAA work on the
+        // final color image, so they need no depth or motion-vector inputs)
         fxaaPipeline = makeCompute("fxaa")
         smaaEdgePipeline = makeCompute("smaaEdgeDetection")
         smaaWeightPipeline = makeCompute("smaaBlendingWeights")
         smaaBlendPipeline = makeCompute("smaaBlend")
-        msaaPipeline = makeCompute("msaa")
-        taaAccumulatePipeline = makeCompute("temporalAccumulation")
 
         // Optical flow / frame generation pipelines
         flowWarpPipeline = makeCompute("flowWarp")
@@ -554,9 +544,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         smaaEdgeTexture = nil
         smaaWeightTexture = nil
         smaaOutputTexture = nil
-        msaaTexture = nil
-        taaHistoryTexture = nil
-        taaOutputTexture = nil
         historyTextures = Array(repeating: nil, count: historyTextures.count)
         historyTextureIndex = 0
         visionFlowProvider?.reset()
@@ -564,7 +551,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         warpedPrevTexture = nil
         warpedNextTexture = nil
         blendTexture = nil
-        hasTAAHistory = false
         lastProcessedSize = .zero
         if clearFrames {
             frameBuffer.clear()
@@ -598,41 +584,43 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         return sharpness * qualityProfile.sharpnessScale
     }
 
-    private func effectiveTemporalBlend() -> Float {
-        return temporalBlend * qualityProfile.temporalBlendScale
+    /// Source frame rate, measured from the interval between unique captured
+    /// frames (duplicates are dropped upstream in WindowCaptureManager).
+    private func measuredSourceFPS() -> Double {
+        if estimatedCaptureInterval > 0 {
+            return 1.0 / estimatedCaptureInterval
+        }
+        if stats.captureFPS > 0 {
+            return Double(stats.captureFPS)
+        }
+        return 0
     }
 
     private func desiredOutputFPS() -> Int {
+        let sourceFPS = measuredSourceFPS()
         var target: Int
-        let captureFPS: Double = {
-            if estimatedCaptureInterval > 0 {
-                return 1.0 / estimatedCaptureInterval
-            }
-            if stats.captureFPS > 0 {
-                return Double(stats.captureFPS)
-            }
-            return 0
-        }()
+
         if frameGenEnabled {
             switch frameGenType {
             case .adaptive:
-                let maxGenFPS = captureFPS > 0 ? Int(round(captureFPS * Double(frameGenMultiplier))) : targetFPS
-                target = min(targetFPS, maxGenFPS)
+                // Generate as many in-between frames as needed to reach the
+                // target (bounded below by the source rate)
+                target = max(targetFPS, Int(round(sourceFPS)))
             case .fixed:
-                let maxGenFPS = captureFPS > 0 ? Int(round(captureFPS * Double(frameGenMultiplier))) : targetFPS
-                target = maxGenFPS
+                // Present a fixed multiple of the real source frames
+                target = sourceFPS > 0 ? Int(round(sourceFPS * Double(frameGenMultiplier))) : targetFPS
             }
-        } else if adaptiveSync {
-            let capture = Int(round(captureFPS))
-            target = capture
         } else {
-            target = currentRefreshRate
+            // No generation: present source frames as they arrive
+            target = sourceFPS > 0 ? Int(round(sourceFPS)) : currentRefreshRate
         }
 
+        // The display can never present faster than its refresh rate, so the
+        // output is physically capped there (e.g. 120 Hz ProMotion → 120 fps)
         if currentRefreshRate > 0 {
             target = min(target, currentRefreshRate)
         }
-        return target
+        return max(1, target)
     }
 
     private func applyFrameRatePreference(_ preferred: Int) {
@@ -672,17 +660,19 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         return captureInterval >= outputInterval ? captureInterval : outputInterval
     }
     
-    func attachToView(_ view: MTKView, refreshRate: Int) {
+    /// - Parameter displayRefreshRate: the panel's maximum refresh rate, which
+    ///   is the physical ceiling for the output frame rate.
+    func attachToView(_ view: MTKView, displayRefreshRate: Int) {
         view.device = device
         view.delegate = self
-        view.preferredFramesPerSecond = refreshRate
+        view.preferredFramesPerSecond = displayRefreshRate
         view.isPaused = false
         view.enableSetNeedsDisplay = false
         view.colorPixelFormat = .bgra8Unorm
         view.framebufferOnly = false
         applyDisplaySync(to: view)
         self.mtkView = view
-        self.currentRefreshRate = refreshRate
+        self.currentRefreshRate = displayRefreshRate
         applyFrameRatePreference(desiredOutputFPS())
     }
     
@@ -718,40 +708,37 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         let frameGenActive = frameGenEnabled
         var isInterpolated = false
 
-        if frameGenEnabled {
-            guard let (prev, next) = frameBuffer.getFramesForTime(targetTime) else {
-                statsLock.lock()
-                _stats.droppedFrames += 1
-                statsLock.unlock()
-                reportError("Error Code: MG-ENG-006 Frame interpolation failed: missing frame pair")
-                commandBuffer.commit()
-                return
-            }
-            let sameSize = prev.texture.width == next.texture.width &&
-                           prev.texture.height == next.texture.height
-            guard sameSize else {
-                statsLock.lock()
-                _stats.droppedFrames += 1
-                statsLock.unlock()
-                reportError("Error Code: MG-ENG-006 Frame interpolation failed: size mismatch")
-                commandBuffer.commit()
-                return
-            }
+        if frameGenEnabled, let (prev, next) = frameBuffer.getFramesForTime(targetTime),
+           prev.texture.width == next.texture.width,
+           prev.texture.height == next.texture.height {
             let duration = next.timestamp - prev.timestamp
             let timeSincePrev = targetTime - prev.timestamp
             let ratio = duration > 0 ? (timeSincePrev / duration) : 0
             let t = Float(min(max(ratio, 0), 1))
-            guard let interpolated = interpolateFrame(prev: prev, next: next, t: t, commandBuffer: commandBuffer) else {
-                statsLock.lock()
-                _stats.droppedFrames += 1
-                statsLock.unlock()
-                reportError("Error Code: MG-ENG-006 Frame interpolation failed: pipeline error")
-                commandBuffer.commit()
-                return
+
+            // Snap to a real (passthrough) frame when the output time lands
+            // within half an output interval of a captured frame, and only
+            // synthesize a frame for genuine in-between phases. This keeps the
+            // accounting honest: output = passthrough + interpolated, with
+            // passthrough tracking the real captured frames.
+            let outputInterval = targetFPS > 0 ? 1.0 / Double(targetFPS) : 0
+            let snap = outputInterval * 0.5
+
+            if duration <= 0 || timeSincePrev <= snap {
+                outputTex = prev.texture
+            } else if (duration - timeSincePrev) <= snap {
+                outputTex = next.texture
+            } else if let interpolated = interpolateFrame(prev: prev, next: next, t: t, commandBuffer: commandBuffer) {
+                outputTex = interpolated
+                isInterpolated = true
+            } else {
+                // Generation unavailable (e.g. flow not ready yet): show the
+                // nearest real frame rather than dropping the output frame
+                outputTex = t < 0.5 ? prev.texture : next.texture
             }
-            outputTex = interpolated
-            isInterpolated = true
         } else {
+            // Frame generation off, or not enough history yet: present the
+            // newest real frame
             outputTex = frameBuffer.newestFrame?.texture
         }
         
@@ -1115,70 +1102,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
             dispatchThreads(pipeline: blendPipe, encoder: encoder, width: input.width, height: input.height)
             encoder.endEncoding()
             return out
-        case .msaa:
-            guard let msaaPipeline = msaaPipeline,
-                  let out = ensureTexture(&msaaTexture, width: input.width, height: input.height),
-                  let encoder = commandBuffer.makeComputeCommandEncoder() else {
-                reportError("Error Code: MG-ENG-007 Anti-aliasing pipeline unavailable (MSAA)")
-                return nil
-            }
-            var params = AntiAliasParams(
-                threshold: qualityProfile.aaThreshold,
-                depthThreshold: 0.1,
-                maxSearchSteps: 8,
-                subpixelBlend: 0.5
-            )
-            encoder.setComputePipelineState(msaaPipeline)
-            encoder.setTexture(input, index: 0)
-            encoder.setTexture(out, index: 1)
-            encoder.setBytes(&params, length: MemoryLayout<AntiAliasParams>.size, index: 0)
-            dispatchThreads(pipeline: msaaPipeline, encoder: encoder, width: input.width, height: input.height)
-            encoder.endEncoding()
-            return out
-        case .taa:
-            guard let taaAccumulatePipeline = taaAccumulatePipeline,
-                  let copyPipeline = copyPipeline,
-                  let history = ensureTexture(&taaHistoryTexture, width: input.width, height: input.height),
-                  let out = ensureTexture(&taaOutputTexture, width: input.width, height: input.height) else {
-                reportError("Error Code: MG-ENG-007 Anti-aliasing pipeline unavailable (TAA)")
-                return nil
-            }
-
-            if !hasTAAHistory {
-                guard let encoder = commandBuffer.makeComputeCommandEncoder() else {
-                    reportError("Error Code: MG-ENG-007 Anti-aliasing pipeline unavailable (TAA)")
-                    return nil
-                }
-                encoder.setComputePipelineState(copyPipeline)
-                encoder.setTexture(input, index: 0)
-                encoder.setTexture(history, index: 1)
-                dispatchThreads(pipeline: copyPipeline, encoder: encoder, width: input.width, height: input.height)
-                encoder.endEncoding()
-                hasTAAHistory = true
-                return input
-            }
-
-            // TAA without motion vectors — neighborhood-clamped accumulation
-            // (Vision flow is async & used for frame gen, so no reprojection here)
-            var blendFactor = effectiveTemporalBlend()
-            guard let encoder = commandBuffer.makeComputeCommandEncoder() else {
-                reportError("Error Code: MG-ENG-007 Anti-aliasing pipeline unavailable (TAA)")
-                return nil
-            }
-            encoder.setComputePipelineState(taaAccumulatePipeline)
-            encoder.setTexture(input, index: 0)
-            encoder.setTexture(history, index: 1)
-            encoder.setTexture(out, index: 2)
-            encoder.setBytes(&blendFactor, length: MemoryLayout<Float>.size, index: 0)
-            dispatchThreads(pipeline: taaAccumulatePipeline, encoder: encoder, width: input.width, height: input.height)
-
-            // Copy to history
-            encoder.setComputePipelineState(copyPipeline)
-            encoder.setTexture(out, index: 0)
-            encoder.setTexture(history, index: 1)
-            dispatchThreads(pipeline: copyPipeline, encoder: encoder, width: input.width, height: input.height)
-            encoder.endEncoding()
-            return out
         }
     }
 
@@ -1283,7 +1206,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
     }
     
     func updateSettings(_ settings: CaptureSettings) {
-        let cursorChanged = settings.captureCursor != captureCursor
         let newScalingType = settings.scalingType
         let newQualityMode = settings.qualityMode
         let newAAMode = settings.aaMode
@@ -1291,18 +1213,18 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         let newRenderScale = shouldScale ? settings.renderScale.multiplier : 1.0
         let newScaleFactor = shouldScale ? settings.scaleFactor.floatValue : 1.0
         let newProfile = newQualityMode.profile
-        
+
         let pipelineChanged =
             newScalingType != scalingType ||
             newQualityMode != qualityMode ||
             newAAMode != aaMode ||
             abs(newRenderScale - renderScaleFactor) > 0.001 ||
             abs(newScaleFactor - scaleFactor) > 0.001
-        
+
         if pipelineChanged {
             resetProcessingState(clearFrames: true)
         }
-        
+
         scalingType = newScalingType
         qualityMode = newQualityMode
         aaMode = newAAMode
@@ -1310,23 +1232,16 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         scaleFactor = newScaleFactor
         qualityProfile = newProfile
         sharpness = settings.sharpening
-        temporalBlend = settings.temporalBlend
-        captureCursor = settings.captureCursor
         frameGenMode = settings.frameGenMode
         frameGenEnabled = settings.frameGenMode != .off
         frameGenType = settings.frameGenType
         targetFPS = settings.targetFPS.intValue
         frameGenMultiplier = settings.frameGenMultiplier.intValue
-        adaptiveSync = settings.adaptiveSync
         vsyncEnabled = settings.vsync
-        
+
         applyFrameRatePreference(desiredOutputFPS())
         if let view = mtkView {
             applyDisplaySync(to: view)
-        }
-
-        if cursorChanged, isCapturing {
-            restartCaptureForCursorChange()
         }
 
         if !frameGenEnabled {
@@ -1338,14 +1253,6 @@ final class GooseEngine: NSObject, ObservableObject, MTKViewDelegate, @unchecked
         }
     }
 
-    private func restartCaptureForCursorChange() {
-        guard let manager = windowCaptureManager else { return }
-        let showsCursor = captureCursor
-        Task {
-            await manager.setShowsCursor(showsCursor)
-        }
-    }
-    
     func startCaptureFromWindow(_ manager: WindowCaptureManager, refreshRate: Int) async {
         resetProcessingState(clearFrames: true)
         resetFrameCounters()

--- a/MetalGoose/OverlayWindowManager.swift
+++ b/MetalGoose/OverlayWindowManager.swift
@@ -10,7 +10,6 @@ struct OverlayWindowConfig {
     var size: CGSize
     var refreshRate: Double
     var vsyncEnabled: Bool
-    var adaptiveSyncEnabled: Bool
     var passThrough: Bool
     var scaleFactor: Float
     var captureCursor: Bool
@@ -206,9 +205,10 @@ class MouseConstraintManager {
     func startConstraining(to rect: CGRect) {
         self.targetRect = rect
         if isConstraining { return }
-        
-        CGDisplayHideCursor(CGMainDisplayID())
-        
+
+        // The system cursor stays visible and is the only cursor on screen
+        // (the capture never bakes a cursor into the frame). We only warp it to
+        // keep it within the target window so clicks land where it points.
         let eventMask = (1 << CGEventType.mouseMoved.rawValue) |
                         (1 << CGEventType.leftMouseDragged.rawValue) |
                         (1 << CGEventType.rightMouseDragged.rawValue) |
@@ -263,7 +263,5 @@ class MouseConstraintManager {
         eventTap = nil
         runLoopSource = nil
         isConstraining = false
-        
-        CGDisplayShowCursor(CGMainDisplayID())
     }
 }

--- a/MetalGoose/Shaders.metal
+++ b/MetalGoose/Shaders.metal
@@ -147,6 +147,9 @@ fragment half4 texture_fragment(
 }
 
 
+// FXAA 3.11 console variant with a relative edge threshold and a subpixel
+// blend pass. Operates purely on the final color image — no depth or motion
+// vectors required.
 kernel void fxaa(
     texture2d<half, access::read> input [[texture(0)]],
     texture2d<half, access::write> output [[texture(1)]],
@@ -160,6 +163,8 @@ kernel void fxaa(
     const half FXAA_REDUCE_MUL = 1.0h / 8.0h;
     const half FXAA_REDUCE_MIN = 1.0h / 128.0h;
     const half FXAA_SPAN_MAX = 8.0h;
+    const half FXAA_EDGE_THRESHOLD_MIN = 1.0h / 24.0h;
+    const half FXAA_SUBPIX = 0.75h;
 
     half3 rgbNW = input.read(uint2(max(0u, gid.x - 1), max(0u, gid.y - 1))).rgb;
     half3 rgbNE = input.read(uint2(min(width - 1, gid.x + 1), max(0u, gid.y - 1))).rgb;
@@ -177,7 +182,10 @@ kernel void fxaa(
     half lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
     half lumaRange = lumaMax - lumaMin;
 
-    if (lumaRange < half(threshold)) {
+    // Relative edge threshold: scale the contrast test with local brightness so
+    // dark and bright regions are treated consistently
+    half edgeThreshold = max(FXAA_EDGE_THRESHOLD_MIN, lumaMax * half(threshold));
+    if (lumaRange < edgeThreshold) {
         output.write(half4(rgbM, 1.0h), gid);
         return;
     }
@@ -205,7 +213,16 @@ kernel void fxaa(
     half3 rgbB = rgbA * 0.5h + (input.read(uint2(pos3)).rgb + input.read(uint2(pos4)).rgb) * 0.25h;
     half lumaB = rgb2luma(rgbB);
 
-    half3 result = (lumaB < lumaMin || lumaB > lumaMax) ? rgbA : rgbB;
+    half3 edgeResult = (lumaB < lumaMin || lumaB > lumaMax) ? rgbA : rgbB;
+
+    // Subpixel aliasing pass: blend toward the local 3x3 average proportional to
+    // how much the center deviates from its neighborhood, softening crawling
+    half3 lowpass = (rgbNW + rgbNE + rgbSW + rgbSE + rgbM) * 0.2h;
+    half lumaLowpass = rgb2luma(lowpass);
+    half subpix = clamp(abs(lumaLowpass - lumaM) / max(lumaRange, FXAA_REDUCE_MIN), 0.0h, 1.0h);
+    subpix = subpix * subpix * FXAA_SUBPIX;
+
+    half3 result = mix(edgeResult, lowpass, subpix);
     output.write(half4(result, 1.0h), gid);
 }
 
@@ -229,6 +246,8 @@ struct AntiAliasParams {
 };
 
 
+// SMAA luma edge detection with local contrast adaptation. This is the base
+// (non-temporal) SMAA pass, so it needs neither depth nor motion vectors.
 kernel void smaaEdgeDetection(
     texture2d<half, access::read> input [[texture(0)]],
     texture2d<half, access::write> edges [[texture(1)]],
@@ -241,21 +260,34 @@ kernel void smaaEdgeDetection(
 
     half threshold = half(params.threshold);
 
-
-    half3 c = input.read(gid).rgb;
-    half3 cLeft = input.read(uint2(max(0u, gid.x - 1), gid.y)).rgb;
-    half3 cTop = input.read(uint2(gid.x, max(0u, gid.y - 1))).rgb;
-
-    half lumaC = rgb2luma(c);
-    half lumaLeft = rgb2luma(cLeft);
-    half lumaTop = rgb2luma(cTop);
-
+    half lumaC    = rgb2luma(input.read(gid).rgb);
+    half lumaLeft = rgb2luma(input.read(uint2(max(0u, gid.x - 1), gid.y)).rgb);
+    half lumaTop  = rgb2luma(input.read(uint2(gid.x, max(0u, gid.y - 1))).rgb);
 
     half2 delta;
     delta.x = abs(lumaC - lumaLeft);
     delta.y = abs(lumaC - lumaTop);
 
     half2 edge = step(threshold, delta);
+    if (edge.x == 0.0h && edge.y == 0.0h) {
+        edges.write(half4(0.0h, 0.0h, 0.0h, 1.0h), gid);
+        return;
+    }
+
+    // Local contrast adaptation: discard edges that are masked by a much
+    // stronger neighbouring edge, which removes most false positives and
+    // ghosting on textured surfaces (standard SMAA refinement).
+    half lumaRight  = rgb2luma(input.read(uint2(min(width - 1, gid.x + 1), gid.y)).rgb);
+    half lumaBottom = rgb2luma(input.read(uint2(gid.x, min(height - 1, gid.y + 1))).rgb);
+    half lumaLeftLeft = rgb2luma(input.read(uint2(max(0u, gid.x - 2), gid.y)).rgb);
+    half lumaTopTop   = rgb2luma(input.read(uint2(gid.x, max(0u, gid.y - 2))).rgb);
+
+    half2 maxDelta;
+    maxDelta.x = max(max(delta.x, abs(lumaC - lumaRight)), abs(lumaLeft - lumaLeftLeft));
+    maxDelta.y = max(max(delta.y, abs(lumaC - lumaBottom)), abs(lumaTop - lumaTopTop));
+
+    half finalDelta = max(maxDelta.x, maxDelta.y);
+    edge *= step(finalDelta * 0.5h, delta);
 
     edges.write(half4(edge.x, edge.y, 0.0h, 1.0h), gid);
 }
@@ -367,86 +399,6 @@ kernel void smaaBlend(
 }
 
 
-
-
-
-
-kernel void temporalAccumulation(
-    texture2d<half, access::read> current [[texture(0)]],
-    texture2d<half, access::read> history [[texture(1)]],
-    texture2d<half, access::write> output [[texture(2)]],
-    constant float& blendFactor [[buffer(0)]],
-    uint2 gid [[thread_position_in_grid]]
-) {
-    uint width = current.get_width();
-    uint height = current.get_height();
-    if (gid.x >= width || gid.y >= height) return;
-
-    half4 curr = current.read(gid);
-    half4 hist = history.read(gid);
-
-
-    half4 minNeighbor = curr;
-    half4 maxNeighbor = curr;
-
-    for (int dy = -1; dy <= 1; dy++) {
-        for (int dx = -1; dx <= 1; dx++) {
-            if (dx == 0 && dy == 0) continue;
-            int2 pos = int2(gid) + int2(dx, dy);
-            pos = clamp(pos, int2(0), int2(width - 1, height - 1));
-            half4 neighbor = current.read(uint2(pos));
-            minNeighbor = min(minNeighbor, neighbor);
-            maxNeighbor = max(maxNeighbor, neighbor);
-        }
-    }
-
-
-    half4 clampedHist = clamp(hist, minNeighbor, maxNeighbor);
-
-
-    half4 result = mix(clampedHist, curr, half(blendFactor));
-    output.write(result, gid);
-}
-
-kernel void msaa(
-    texture2d<half, access::read> input [[texture(0)]],
-    texture2d<half, access::write> output [[texture(1)]],
-    constant AntiAliasParams& params [[buffer(0)]],
-    uint2 gid [[thread_position_in_grid]]
-) {
-    uint width = input.get_width();
-    uint height = input.get_height();
-    if (gid.x >= width || gid.y >= height) return;
-
-
-    half4 center = input.read(gid);
-    half centerLuma = rgb2luma(center.rgb);
-
-    half4 sum = center;
-    half weightSum = 1.0h;
-
-    for (int dy = -1; dy <= 1; dy++) {
-        for (int dx = -1; dx <= 1; dx++) {
-            if (dx == 0 && dy == 0) continue;
-
-            int2 pos = int2(gid) + int2(dx, dy);
-            if (pos.x < 0 || pos.x >= int(width) ||
-                pos.y < 0 || pos.y >= int(height)) continue;
-
-            half4 neighbor = input.read(uint2(pos));
-            half neighborLuma = rgb2luma(neighbor.rgb);
-
-
-            half diff = abs(centerLuma - neighborLuma);
-            half weight = exp(-diff * 10.0h) * 0.5h;
-
-            sum += neighbor * weight;
-            weightSum += weight;
-        }
-    }
-
-    output.write(sum / weightSum, gid);
-}
 
 
 

--- a/MetalGoose/WindowCaptureManager.swift
+++ b/MetalGoose/WindowCaptureManager.swift
@@ -9,15 +9,14 @@ import os
 
 @available(macOS 26.0, *)
 final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, SCStreamOutput, @unchecked Sendable {
-    
+
     private let captureQueue = DispatchQueue(label: "com.metalgoose.capture", qos: .userInteractive)
-    
+
     @Published private(set) var isActive: Bool = false
     @Published private(set) var lastError: String?
     @Published private(set) var currentResolution: CGSize = .zero
-    
+
     private var stream: SCStream?
-    private var configuration: SCStreamConfiguration?
 
     // The pixel buffer must be retained until the GPU finishes reading the
     // IOSurface, otherwise ScreenCaptureKit recycles it mid-frame.
@@ -37,7 +36,10 @@ final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, 
         return screen?.backingScaleFactor ?? 2.0
     }
 
-    func startCapture(windowID: CGWindowID, refreshRate: Int, showsCursor: Bool) async -> Bool {
+    /// Captures the window at up to `maxFPS` frames per second (typically the
+    /// display's refresh rate). The real source frame rate is recovered by
+    /// dropping duplicate frames, so frame generation has headroom to work.
+    func startCapture(windowID: CGWindowID, maxFPS: Int) async -> Bool {
         await stopCapture()
 
         do {
@@ -59,12 +61,15 @@ final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, 
             let config = SCStreamConfiguration()
             config.width = Int(pixelSize.width)
             config.height = Int(pixelSize.height)
-            config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(refreshRate))
+            config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(max(1, maxFPS)))
             config.pixelFormat = kCVPixelFormatType_32BGRA
-            config.showsCursor = showsCursor
+            // The cursor is never baked into the captured frame; the real
+            // system cursor floats over the overlay at native resolution and
+            // zero latency, so there is exactly one cursor on screen.
+            config.showsCursor = false
 
             // Critical settings for minimum latency and zero-copy mapping
-            config.queueDepth = 2
+            config.queueDepth = 3
             config.captureResolution = .best
             config.shouldBeOpaque = false
             config.backgroundColor = .clear
@@ -74,7 +79,6 @@ final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, 
             try await captureStream.startCapture()
 
             self.stream = captureStream
-            self.configuration = config
             await MainActor.run {
                 currentResolution = pixelSize
                 isActive = true
@@ -88,20 +92,6 @@ final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, 
                 lastError = "Error Code: MG-CAP-002 ScreenCaptureKit start error: \(error.localizedDescription)"
             }
             return false
-        }
-    }
-
-    /// Toggles cursor capture on the running stream without a restart
-    func setShowsCursor(_ shows: Bool) async {
-        guard let stream = stream, let configuration = configuration,
-              configuration.showsCursor != shows else { return }
-        configuration.showsCursor = shows
-        do {
-            try await stream.updateConfiguration(configuration)
-        } catch {
-            await MainActor.run {
-                lastError = "Error Code: MG-CAP-005 Cursor visibility update failed: \(error.localizedDescription)"
-            }
         }
     }
 
@@ -119,10 +109,9 @@ final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, 
             }
         }
         stream = nil
-        configuration = nil
         await MainActor.run { isActive = false }
     }
-    
+
     nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
         Task { @MainActor in
             let nsError = error as NSError
@@ -132,24 +121,35 @@ final class WindowCaptureManager: NSObject, ObservableObject, SCStreamDelegate, 
             self.stream = nil
         }
     }
-    
+
     nonisolated func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .screen else { return }
-        
+
         guard let attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
               let attachments = attachmentsArray.first else {
             return
         }
-        
+
         guard let statusRawValue = attachments[SCStreamFrameInfo.status] as? Int,
               let status = SCFrameStatus(rawValue: statusRawValue),
               status == .complete else {
+            // .idle / .blank / .suspended frames carry no new content
             return
         }
-        
+
+        // Drop duplicate frames: when ScreenCaptureKit reports no dirty rects,
+        // the window content is identical to the previous frame. Skipping these
+        // makes the reported capture rate reflect the real source frame rate and
+        // gives frame generation genuinely different frames to interpolate.
+        // If the attachment is absent we conservatively treat the frame as new.
+        if let dirtyRects = attachments[SCStreamFrameInfo.dirtyRects] as? [[String: Any]],
+           dirtyRects.isEmpty {
+            return
+        }
+
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
         guard let surface = CVPixelBufferGetIOSurface(pixelBuffer)?.takeUnretainedValue() else { return }
-        
+
         let timestamp = CMTimeGetSeconds(CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
 
         onFrameReceived?(surface, pixelBuffer, timestamp)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ MetalGoose is a native macOS application that provides real-time upscaling and f
 - Quality modes: Performance, Balanced, Quality
 
 ### Anti-Aliasing
-- **FXAA** — Fast approximate anti-aliasing
-- **SMAA** — Enhanced subpixel morphological AA
-- **MSAA** — Multi-sample anti-aliasing
-- **TAA** — Temporal anti-aliasing with history
+Post-process anti-aliasing that runs on the final captured image, with no need
+for depth buffers or motion vectors:
+- **FXAA** — Fast approximate anti-aliasing (relative edge threshold + subpixel pass)
+- **SMAA** — Subpixel morphological AA with local contrast adaptation
 
 ### Performance Monitoring
 - Real-time HUD overlay
@@ -103,7 +103,6 @@ open MetalGoose.xcodeproj
 - MG-CAP-002: ScreenCaptureKit start error.
 - MG-CAP-003: ScreenCaptureKit stop error.
 - MG-CAP-004: Stream stopped with error.
-- MG-CAP-005: Cursor visibility update failed.
 
 ## Engine (MG-ENG)
 - MG-ENG-001: Metal pipeline setup failed.


### PR DESCRIPTION
Bu PR, ekran görüntüleriyle bildirilen sorunları ele alıyor ve MetalGoose'u MacOS'ta daha sağlam bir Lossless Scaling alternatifine yaklaştırıyor.

## 1. Çift imleç düzeltmesi
- İmleç artık yakalanan kareye **bake edilmiyor** (`showsCursor = false`) ve sistem imleci **gizlenmiyor**. Sonuç: ekranda her zaman tek bir imleç (keskin, sıfır gecikmeli sistem imleci).
- "Capture Cursor" anahtarı artık yalnızca imleci hedef pencere içine **kısıtlıyor** (warp), böylece tıklamalar imlecin gösterdiği yere gidiyor. Açık/kapalı her iki durumda da tek imleç görünür.

## 2. VSync / Adaptive Sync
- Gereksiz **Adaptive Sync** seçeneği tüm kod tabanından kaldırıldı (ayarlar, motor, overlay config, UI, profiller). Kare hızı artık ölçülen kaynak hızı ve VSync ile yönetiliyor.

## 3. Anti-aliasing
- Motion vector ve depth olmadan doğru çalışamayan **TAA ve MSAA kaldırıldı**.
- Yalnızca renk görüntüsü üzerinde çalışan **FXAA ve temel SMAA korundu ve iyileştirildi**:
  - FXAA: göreli kenar eşiği + subpixel blend geçişi.
  - SMAA: kenar tespitine yerel kontrast adaptasyonu (yanlış kenarları azaltır).
- Kullanılmayan `msaa` ve `temporalAccumulation` kernel'leri silindi.

## 4. Frame generation ve FPS mantığı
Bildirilen "oyun 30 FPS ama capture/output/interpolated ~120" ve "neredeyse hiç fark hissetmedim" sorunlarının kök nedeni: yakalama hedef FPS'te (120) sabitlenmişti ve **her yakalanan kare** (kopyalar dahil) ring buffer'a gidip neredeyse özdeş kareler arasında interpolasyon yapılıyordu — yani frame gen pratikte hiçbir şey üretmiyordu.

Değişiklikler:
- **Yinelenen kare tespiti**: ScreenCaptureKit `dirtyRects` ile içeriği değişmeyen kareler atlanıyor; böylece bildirilen capture FPS gerçek kaynak hızını yansıtıyor ve interpolasyon gerçekten farklı kareler arasında çalışıyor.
- Yakalama artık panelin gerçek yenileme hızında yapılıyor (`NSScreen.maximumFramesPerSecond`).
- **Çıkış pacing'i yeniden yazıldı**: fixed mod = kaynak × çarpan; adaptive mod = hedefe ulaşır; çıkış panel yenileme hızında sınırlanır (fiziksel tavan, ör. 120 Hz ProMotion).
- **Passthrough vs interpolated dürüst sayımı**: çıkış zamanı gerçek yakalanan karelere "snap" ediliyor; artık `output = passthrough + interpolated` (önceden her kare interpolated sayılıyordu).

### "120 FPS limiti" hakkında not
Yapay bir 120 sınırı yok — bu, **120 Hz ProMotion panelinin fiziksel yenileme hızı**. Çıkış bunun üzerine çıkamaz. Frame gen'in hissedilmesi için kaynağın panel hızının **altında** olması gerekir (klasik LSFG senaryosu: 60→120, 30→120). Ekran görüntülerindeki hile-istemci HUD'u (Auto Reconnect / koordinatlar) **her karede** güncellendiği için her yakalanan kare benzersiz oluyor; bu yüzden MetalGoose o senaryoda doğru biçimde ~120 benzersiz kare görüyor — "30 FPS limiti" pencere güncellemelerini gerçekte azaltmıyor.

## Doğrulama notu
Bu ortam Linux olduğundan **derleme/çalıştırma doğrulaması yapılamadı**; değişiklikler sözdizimi, referans tutarlılığı ve brace dengesi açısından kontrol edildi. macOS 26 / Xcode 26'da bir kez derleyip özellikle frame gen (kaynağı panel hızının altına indirip HUD'da passthrough+interpolated=output'u görmek) ve imleç davranışını gözle doğrulamanızı öneririm.

https://claude.ai/code/session_017zxjXrxWUtkgPXJwz3vwUK

---
_Generated by [Claude Code](https://claude.ai/code/session_017zxjXrxWUtkgPXJwz3vwUK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved frame generation timing and display refresh rate synchronization
  * Enhanced FXAA and SMAA anti-aliasing with better edge detection and subpixel processing
  * Simplified cursor handling during capture

* **Changes**
  * Removed MSAA and TAA anti-aliasing options; FXAA and SMAA remain available
  * Updated VSync configuration to use display refresh rate settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->